### PR TITLE
Implementação da interface Serializable na classe Endereco

### DIFF
--- a/src/main/java/com/soulcode/goserviceapp/domain/Endereco.java
+++ b/src/main/java/com/soulcode/goserviceapp/domain/Endereco.java
@@ -3,12 +3,13 @@ package com.soulcode.goserviceapp.domain;
 
 import jakarta.persistence.*;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 
 @Entity
 @Table(name = "enderecos")
-public class Endereco {
+public class Endereco implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
- [x] Implementação da interface Serializable na classe Endereco
     
     - Ao tentar procurar os serviços agendados, não estava retornando nenhum dado do banco, pois a nova classe que foi implementada(Endereco) não tinha a interface Serializable implementada, havendo então um conflito com a classe usuário que tem métodos "cacheados" que necessitam da implementação do Serializable